### PR TITLE
12 persistent chat history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,8 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+### SQLite
+# SQLite database file
+*.sqlite
+
 # End of https://www.toptal.com/developers/gitignore/api/rust,macos,windows,linux,visualstudiocode,emacs,vim

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = "1.0.115"
 tokio = {version = "1.37.0", features = ["full"]}
 toml = "0.8.12"
 shared = {path = "../shared"}
+rusqlite = "0.31.0"

--- a/server/config.toml
+++ b/server/config.toml
@@ -1,1 +1,2 @@
 listen_address = "127.0.0.1:5656"
+db_path = "./server.sqlite"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,7 @@
-use shared::Message;
+use rusqlite::Connection;
+use shared::{Message, TextMessage};
 use serde_json::{from_str, to_string};
+use std::error::Error;
 use std::sync::Arc;
 use tokio::net::{TcpListener, tcp};
 use tokio::sync::{mpsc, Mutex};
@@ -9,26 +11,35 @@ use toml::Table;
 struct Server<> {
     config: Table,
     write_streams: Arc<Mutex<Vec<(std::net::SocketAddr, tcp::OwnedWriteHalf)>>>,
+    database: Arc<Mutex<Connection>>,
 }
 
 impl Server {
-    fn new(config: String) -> Server{
-        let config = config.parse::<Table>().expect("Failed to parse config file");
-        Server {
+    fn new(config: String) -> Result<Server, Box<dyn Error>>{
+        let config = config.parse::<Table>()?;
+        let db_address = config["db_path"].as_str().ok_or("Invalid database path")?;
+        let database = Arc::new(Mutex::new(Connection::open(db_address)?));
+        Ok(Server {
             config,
             write_streams: Arc::new(Mutex::new(Vec::new())),
-        }
+            database,
+        })
     }
 
-    async fn start(mut self) -> Result<(), Box<dyn std::error::Error>>{
+    async fn start(mut self) -> Result<(), Box<dyn Error>>{
         let listener = TcpListener::bind(self.config["listen_address"].as_str().ok_or("Invalid address")?).await?;
-        let (message_tx, message_rx) = mpsc::channel::<Message>(1);
-        self.begin_listen(listener, message_tx);
-        self.begin_broadcast(message_rx);
+
+        let (text_tx_raw, text_rx_raw) = mpsc::channel::<TextMessage>(1);
+        let (text_tx_processed, text_rx_processed) = mpsc::channel::<TextMessage>(1);
+
+        self.begin_listen(listener, text_tx_raw);
+        self.begin_broadcast(text_rx_processed);
+        tokio::spawn(process_and_save(self.database.clone(), text_rx_raw, text_tx_processed));
+        
         Ok(())
     }
 
-    fn begin_listen(&mut self, listener: TcpListener, message_tx: mpsc::Sender<Message>) {
+    fn begin_listen(&mut self, listener: TcpListener, text_tx: mpsc::Sender<TextMessage>) {
         let write_streams = self.write_streams.clone();
         tokio::spawn(async move {
             loop {
@@ -42,13 +53,13 @@ impl Server {
                 let (read_stream, write_stream) = stream.into_split();
                 let mut writes_locked = write_streams.lock().await;
                 writes_locked.push((address, write_stream));
-                tokio::spawn(listen_messages(read_stream, message_tx.clone()));
+                tokio::spawn(listen_messages(read_stream, text_tx.clone()));
             
             }
         });
     }
 
-    fn begin_broadcast(&self, mut message_rx: mpsc::Receiver<Message>) {
+    fn begin_broadcast(&self, mut message_rx: mpsc::Receiver<TextMessage>) {
         let write_streams = self.write_streams.clone();
         tokio::spawn(async move {
             while let Some(message) = message_rx.recv().await {
@@ -78,14 +89,13 @@ impl Server {
 #[tokio::main]
 async fn main() {
     let config = std::fs::read_to_string("config.toml").expect("Failed to read config file");
-    let server = Server::new(config);
+    let server = Server::new(config).expect("Failed to start server");
     server.start().await.expect("Failed to start server");
     loop {}
 }
 
-
-
-async fn listen_messages(stream: tcp::OwnedReadHalf, message_tx: mpsc::Sender<Message>) {
+async fn listen_messages(stream: tcp::OwnedReadHalf, text_tx: mpsc::Sender<TextMessage>) {
+    use shared::Message as m;
     let mut reader = BufReader::new(stream);
     let mut buffer = String::new();
     loop {
@@ -97,6 +107,61 @@ async fn listen_messages(stream: tcp::OwnedReadHalf, message_tx: mpsc::Sender<Me
             Ok(data) => data,
             Err(_) => return 
         };
-        message_tx.send(message).await.unwrap();
+        match message {
+            m::Text(content) => {text_tx.send(content).await.unwrap();},
+            _ => {}
+        };
     }
+}
+
+/// Add server-supplied data and write chat history to the server's database
+async fn process_and_save(
+    db: Arc<Mutex<Connection>>,
+    mut text_rx_raw: mpsc::Receiver<TextMessage>,
+    text_tx_processed: mpsc::Sender<TextMessage>
+) -> rusqlite::Result<()> {
+    // Make sure that we actually have a history table
+    {
+        let db_locked = db.lock().await;
+        let query = "
+        CREATE TABLE IF NOT EXISTS history
+        (
+            id INTEGER PRIMARY KEY,
+            username TEXT NOT NULL,
+            body TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            embed_pointer INTEGER,
+            embed_type TEXT
+        );";
+        db_locked.execute(&query, ()).unwrap();
+    }
+    // Await messages to process and send
+    while let Some(mut msg) = text_rx_raw.recv().await {
+        // First process the message by adding server-supplied data
+        msg.timestamp = match std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH) {
+            Ok(time) => time.as_secs(),
+            Err(_) => 0,
+        };
+        
+        
+        // Then write it to the database
+        // This scope is important in case of any awaits afterwards
+        {
+            // Write
+            let query = format!("
+            INSERT INTO history (username, body, timestamp)
+            VALUES('{username}', '{body}', '{timestamp}');
+            ", username = msg.username, body = msg.body, timestamp = msg.timestamp);
+            let db_locked = db.lock().await;
+            db_locked.execute(&query, ()).unwrap();
+
+            // Retrieve id
+            msg.message_id = Some(db_locked.last_insert_rowid() as u32);
+        }
+
+        // When we know the write is successful, send the processed message to be broadcast
+        text_tx_processed.send(msg).await.unwrap();
+    }
+    println!("process and save exiting");
+    Ok(())
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,13 +1,13 @@
-use serde::{Serialize, Deserialize};
+pub use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Message {
     Text(TextMessage),
     File(FileMessage),
     Command(CommandMessage),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TextMessage {
     pub username: String,
     pub auth_token: String,
@@ -18,7 +18,7 @@ pub struct TextMessage {
     pub timestamp: u64
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct FileMessage {
     pub username: String,
     pub auth_token: String,
@@ -26,7 +26,7 @@ pub struct FileMessage {
     pub data: String
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct CommandMessage {
     pub username: String,
     pub auth_token: String,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,7 +1,14 @@
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize)]
-pub struct Message {
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Message {
+    Text(TextMessage),
+    File(FileMessage),
+    Command(CommandMessage),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TextMessage {
     pub username: String,
     pub auth_token: String,
     pub body: String,
@@ -11,16 +18,16 @@ pub struct Message {
     pub timestamp: u64
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct File {
+#[derive(Serialize, Deserialize, Clone)]
+pub struct FileMessage {
     pub username: String,
     pub auth_token: String,
     pub filename: String,
     pub data: String
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct Command {
+#[derive(Serialize, Deserialize, Clone)]
+pub struct CommandMessage {
     pub username: String,
     pub auth_token: String,
     pub command_type: String,


### PR DESCRIPTION
All incoming messages are written to a SQLite database to create a persistent chat history. Using the `history` command users can request a specified number of messages from the database.
Fix #12 