### PR TITLE
14 enable authentication

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,3 +11,6 @@ tokio = {version = "1.37.0", features = ["full"]}
 toml = "0.8.12"
 shared = {path = "../shared"}
 rusqlite = "0.31.0"
+rand = "0.8.5"
+sha2 = "0.10.8"
+base64ct = { version = "1.6.0", features = ["alloc"] }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -39,5 +39,5 @@ pub struct CommandMessage {
 pub struct AuthMessage {
     pub username: String,
     pub auth_token: Option<String>,
-    pub pass_hash: Option<String>
+    pub password: Option<String>
 }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -8,6 +8,28 @@ pub enum Message {
     Auth(AuthMessage)
 }
 
+impl Message {
+    pub fn username(&self) -> String {
+        use Message as m;
+        match self {
+            m::Text(inner) => inner.username.clone(),
+            m::File(inner) => inner.username.clone(),
+            m::Command(inner) => inner.username.clone(),
+            m::Auth(inner) => inner.username.clone()
+        }
+    }
+
+    pub fn auth_token(&self) -> Option<String> {
+        use Message as m;
+        match self {
+            m::Text(inner) => Some(inner.auth_token.clone()),
+            m::File(inner) => Some(inner.auth_token.clone()),
+            m::Command(inner) => Some(inner.auth_token.clone()),
+            m::Auth(inner) => inner.auth_token.clone()
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TextMessage {
     pub username: String,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,6 +5,7 @@ pub enum Message {
     Text(TextMessage),
     File(FileMessage),
     Command(CommandMessage),
+    Auth(AuthMessage)
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -32,4 +33,11 @@ pub struct CommandMessage {
     pub auth_token: String,
     pub command_type: String,
     pub args: Vec<String>
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AuthMessage {
+    pub username: String,
+    pub auth_token: Option<String>,
+    pub pass_hash: Option<String>
 }


### PR DESCRIPTION
Users are authenticated via a first authentication message and then given a random session token that must be used in all subsequent messages. Passwords are salted, hashed and stored in a SQLite table
Fix #14