### PR TITLE
16 support multiple channels

### DIFF
--- a/server/config.toml
+++ b/server/config.toml
@@ -1,2 +1,5 @@
 listen_address = "127.0.0.1:5656"
 db_path = "./server.sqlite"
+
+# Server properties
+channels = ["general", "general_2"]

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -35,6 +35,7 @@ pub struct TextMessage {
     pub username: String,
     pub auth_token: String,
     pub body: String,
+    pub channel: String, // The message's target channel
     pub embed_pointer: Option<usize>,
     pub embed_type: Option<String>,
     pub message_id: Option<u32>,


### PR DESCRIPTION
The server now has a list of channels defined in config.toml, with each getting its own SQLite table. The TextMessage struct has a new `channel` field that determines which channel it is saved to and can be used client-side to hide or display. The `history` command now uses the `channel` argument to determine which table to pull from.
Fix #16 